### PR TITLE
darwin-arm64: bring to sanity

### DIFF
--- a/src/cwb/config/platform/darwin-arm64
+++ b/src/cwb/config/platform/darwin-arm64
@@ -17,8 +17,7 @@
 
 ##
 ##  PLATFORM CONFIGURATION FILE: 
-##  Recent Mac OS X with Xcode 5 or later on 64-bit Intel Core2 and newer CPUs, natively tuned,
-##  with prerequisite libraries installed by user or package manager in standard locations
+##  Recent Mac OS X with on Apple M CPUs.
 ##
 
 ## Inherits from basic Darwin configuration
@@ -33,6 +32,4 @@ CFLAGS = -Wall -O3 -arch arm64 -mtune=native
 DEPEND_CFLAGS = -Wall -O3
 
 ## CPU architecture and operating system used to name binary releases
-RELEASE_ARCH = x86_64
-RELEASE_OS = osx-10.7
-
+RELEASE_ARCH = arm64


### PR DESCRIPTION
Wrong arch in that config file, macOS version which does not exist on `aarch64`.